### PR TITLE
Add MainActivity ViewModel

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,18 +24,18 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
-            buildConfigField "String", "API_BASE_URL_V3", "\"https://api.themoviedb.org/3/\""
-            buildConfigField "String", "POSTER_BASE_URL", "\"http://image.tmdb.org/t/p/w154//\""
+            buildConfigField "String", "API_BASE_URL_V3", "\"https://api.themoviedb.org/\""
+            buildConfigField "String", "POSTER_BASE_URL", "\"https://image.tmdb.org/t/p/w154//\""
             //TODO replace the API KEY with the one issued from TMDB
-            buildConfigField "String", "API_KEY", "\"API_KEY\""
+            buildConfigField "String", "API_KEY", "\"f19d91a5929903ec923e8d9f11ae024d\""
         }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            buildConfigField "String", "API_BASE_URL_V3", "\"https://api.themoviedb.org/3/\""
-            buildConfigField "String", "POSTER_BASE_URL", "\"http://image.tmdb.org/t/p/w154//\""
+            buildConfigField "String", "API_BASE_URL_V3", "\"https://api.themoviedb.org/\""
+            buildConfigField "String", "POSTER_BASE_URL", "\"https://image.tmdb.org/t/p/w154//\""
             //TODO replace the API KEY with the one issued from TMDB
-            buildConfigField "String", "API_KEY", "\"API_KEY\""
+            buildConfigField "String", "API_KEY", "\"f19d91a5929903ec923e8d9f11ae024d\""
         }
     }
     compileOptions {
@@ -58,6 +58,7 @@ dependencies {
 
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.9.1'
 
     implementation 'com.squareup.retrofit2:adapter-rxjava2:2.4.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.4.0'

--- a/app/src/main/java/com/example/moviedb/MovieDBApplication.kt
+++ b/app/src/main/java/com/example/moviedb/MovieDBApplication.kt
@@ -3,10 +3,13 @@ package com.example.moviedb
 import android.app.Application
 import com.example.moviedb.networking.interceptors.AuthInterceptor
 import com.example.moviedb.networking.services.MovieService
+import com.example.moviedb.repositories.MovieRepository
 import com.example.moviedb.sources.LocalMovieSource
 import com.example.moviedb.sources.RemoteMovieSource
 import io.realm.Realm
+import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import org.koin.android.ext.android.startKoin
 import org.koin.dsl.module.module
 import retrofit2.Retrofit
@@ -15,28 +18,41 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 class MovieDBApplication : Application() {
 
-    private val appModule = module {
-        single { Realm.getDefaultInstance() }
-        single { LocalMovieSource(get()) }
-        single { RxJava2CallAdapterFactory.create() }
-        single { GsonConverterFactory.create() }
-        single { OkHttpClient.Builder().addInterceptor(AuthInterceptor()) }
-        single {
-            Retrofit.Builder().baseUrl(BuildConfig.API_BASE_URL_V3)
-                .client(get())
-                .addConverterFactory(get())
-                .addCallAdapterFactory(get())
-                .build()
+    private val appModule by lazy {
+        module {
+            single { Realm.init(this@MovieDBApplication) }
+            single { Realm.getDefaultInstance() }
+            single { LocalMovieSource(get()) }
+            single {
+                val httpLoggingInterceptor = HttpLoggingInterceptor()
+                httpLoggingInterceptor.level = HttpLoggingInterceptor.Level.BASIC
+                val builder = OkHttpClient.Builder()
+                        .addInterceptor(AuthInterceptor())
+                if (BuildConfig.DEBUG) {
+                    builder.addInterceptor(httpLoggingInterceptor)
+                }
+
+                builder.build()
+            }
+            single {
+                Retrofit.Builder().baseUrl(HttpUrl.parse(BuildConfig.API_BASE_URL_V3)!!)
+                        .client(get())
+                        .addConverterFactory(GsonConverterFactory.create())
+                        .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+                        .build()
+            }
+            single {
+                val retrofit: Retrofit = get()
+                retrofit.create(MovieService::class.java)
+            }
+            single { RemoteMovieSource(get()) }
+            single { MovieRepository(get(), get()) }
         }
-        single {
-            val retrofit: Retrofit = get()
-            retrofit.create(MovieService::class.java)
-        }
-        single { RemoteMovieSource(get()) }
     }
 
     override fun onCreate() {
         super.onCreate()
+        Realm.init(this)
         startKoin(this, listOf(appModule))
     }
 }

--- a/app/src/main/java/com/example/moviedb/MovieItemDecorator.kt
+++ b/app/src/main/java/com/example/moviedb/MovieItemDecorator.kt
@@ -1,0 +1,13 @@
+package com.example.moviedb
+
+import android.graphics.Rect
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+class MovieItemDecorator : RecyclerView.ItemDecoration() {
+
+    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
+        outRect.top = view.resources?.getDimensionPixelOffset(R.dimen.half_margin) ?: 0
+        outRect.bottom = view.resources?.getDimensionPixelOffset(R.dimen.half_margin) ?: 0
+    }
+}

--- a/app/src/main/java/com/example/moviedb/activities/MainActivity.kt
+++ b/app/src/main/java/com/example/moviedb/activities/MainActivity.kt
@@ -18,13 +18,13 @@ import io.reactivex.disposables.Disposable
 import io.reactivex.observers.DisposableObserver
 import org.koin.android.ext.android.inject
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(), MovieAdapter.OnMovieClickedListener {
 
     private val movieRepository: MovieRepository by inject()
 
     private var disposables: CompositeDisposable = CompositeDisposable()
 
-    private val movieAdapter = MovieAdapter()
+    private val movieAdapter = MovieAdapter(this)
 
     private lateinit var dataBinding: ActivityMainBinding
 
@@ -75,6 +75,10 @@ class MainActivity : AppCompatActivity() {
             disposables = CompositeDisposable()
         }
         disposables.add(disposable)
+    }
+
+    override fun onMovieClicked(m: Movie) {
+        startActivity(MovieDetailActivity.getIntent(this, m.id))
     }
 
 }

--- a/app/src/main/java/com/example/moviedb/activities/MainActivity.kt
+++ b/app/src/main/java/com/example/moviedb/activities/MainActivity.kt
@@ -1,13 +1,80 @@
 package com.example.moviedb.activities
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.moviedb.MovieItemDecorator
 import com.example.moviedb.R
+import com.example.moviedb.adapters.MovieAdapter
+import com.example.moviedb.databinding.ActivityMainBinding
+import com.example.moviedb.models.DelegateUIModel
+import com.example.moviedb.models.GenericUIModel
+import com.example.moviedb.models.Movie
+import com.example.moviedb.repositories.MovieRepository
+import com.example.moviedb.viewmodels.MovieViewModel
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.disposables.Disposable
+import io.reactivex.observers.DisposableObserver
+import org.koin.android.ext.android.inject
 
 class MainActivity : AppCompatActivity() {
 
+    private val movieRepository: MovieRepository by inject()
+
+    private var disposables: CompositeDisposable = CompositeDisposable()
+
+    private val movieAdapter = MovieAdapter()
+
+    private lateinit var dataBinding: ActivityMainBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        dataBinding = DataBindingUtil.setContentView(this, R.layout.activity_main)
+        dataBinding.recyclerview.apply {
+            adapter = movieAdapter
+            layoutManager = LinearLayoutManager(this@MainActivity)
+            addItemDecoration(MovieItemDecorator())
+        }
+
     }
+
+    override fun onResume() {
+        super.onResume()
+        movieAdapter.clearItemsAndNotify()
+        dataBinding.swipeRefreshLayout.isRefreshing = true
+        addDisposable(MovieViewModel(movieRepository).getPopularMovies().subscribeWith(object :
+                DisposableObserver<Movie>() {
+            override fun onComplete() {
+            }
+
+            override fun onNext(t: Movie) {
+                if (dataBinding.swipeRefreshLayout.isRefreshing) {
+                    dataBinding.swipeRefreshLayout.isRefreshing = false
+                }
+                movieAdapter.addItemAndNotify(t)
+            }
+
+            override fun onError(e: Throwable) {
+                if (dataBinding.swipeRefreshLayout.isRefreshing) {
+                    dataBinding.swipeRefreshLayout.isRefreshing = false
+                }
+                movieAdapter.clearItemsAndNotify()
+                movieAdapter.addItemAndNotify(GenericUIModel(DelegateUIModel.ERROR_ITEM))
+            }
+        }))
+    }
+
+    override fun onPause() {
+        super.onPause()
+        disposables.dispose()
+    }
+
+    private fun addDisposable(disposable: Disposable) {
+        if (disposables.isDisposed) {
+            disposables = CompositeDisposable()
+        }
+        disposables.add(disposable)
+    }
+
 }

--- a/app/src/main/java/com/example/moviedb/activities/MovieDetailActivity.kt
+++ b/app/src/main/java/com/example/moviedb/activities/MovieDetailActivity.kt
@@ -5,15 +5,17 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.GravityCompat
 import com.example.moviedb.R
 import kotlinx.android.synthetic.main.activity_movie_detail.*
 
 class MovieDetailActivity : AppCompatActivity() {
 
     companion object {
-        fun getIntent(context: Context): Intent {
-            return Intent(context, MovieDetailActivity::class.java)
+        private const val MOVIE_ID = "MOVIE_ID"
+        fun getIntent(context: Context, movieId: Int): Intent {
+            return Intent(context, MovieDetailActivity::class.java).apply {
+                putExtra(MOVIE_ID, movieId)
+            }
         }
     }
 

--- a/app/src/main/java/com/example/moviedb/adapters/MovieAdapter.kt
+++ b/app/src/main/java/com/example/moviedb/adapters/MovieAdapter.kt
@@ -4,10 +4,20 @@ import com.example.moviedb.R
 import com.example.moviedb.delegates.GenericDelegateAdapter
 import com.example.moviedb.delegates.MovieDelegateAdapter
 import com.example.moviedb.models.DelegateUIModel
+import com.example.moviedb.models.Movie
 
-class MovieAdapter : BaseAdapter() {
+class MovieAdapter(private val onMovieClickedListener: OnMovieClickedListener) : BaseAdapter(), MovieDelegateAdapter.OnMovieItemListener {
+
+    interface OnMovieClickedListener {
+        fun onMovieClicked(m: Movie)
+    }
+
     init {
-        addDelegate(MovieDelegateAdapter(), DelegateUIModel.MOVIE_ITEM)
+        addDelegate(MovieDelegateAdapter(this), DelegateUIModel.MOVIE_ITEM)
         addDelegate(GenericDelegateAdapter(R.layout.item_error), DelegateUIModel.ERROR_ITEM)
+    }
+
+    override fun onMovieClicked(pos: Int) {
+        onMovieClickedListener.onMovieClicked(getItem(pos))
     }
 }

--- a/app/src/main/java/com/example/moviedb/delegates/MovieDelegateAdapter.kt
+++ b/app/src/main/java/com/example/moviedb/delegates/MovieDelegateAdapter.kt
@@ -7,6 +7,7 @@ import androidx.databinding.BindingAdapter
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.NO_POSITION
 import com.example.moviedb.BR
 import com.example.moviedb.R
 import com.example.moviedb.models.DelegateUIModel
@@ -14,7 +15,11 @@ import com.example.moviedb.models.Movie
 import com.squareup.picasso.Picasso
 
 
-class MovieDelegateAdapter : DelegateAdapter {
+class MovieDelegateAdapter(private val onMovieItemListener: OnMovieItemListener) : DelegateAdapter {
+
+    interface OnMovieItemListener {
+        fun onMovieClicked(pos: Int)
+    }
 
     companion object {
         @BindingAdapter("bind_imageUrl")
@@ -30,11 +35,10 @@ class MovieDelegateAdapter : DelegateAdapter {
         }
     }
 
-
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
         val viewDataBinding = DataBindingUtil.inflate<ViewDataBinding>(layoutInflater, R.layout.item_movie, parent, false)
-        return MovieViewHolder(viewDataBinding)
+        return MovieViewHolder(viewDataBinding, onMovieItemListener)
     }
 
     override fun onBindViewHolder(viewHolder: RecyclerView.ViewHolder, delegateUIModel: DelegateUIModel) {
@@ -45,8 +49,17 @@ class MovieDelegateAdapter : DelegateAdapter {
     }
 
 
-    inner class MovieViewHolder(val binding: ViewDataBinding) :
-            RecyclerView.ViewHolder(binding.root)
+    inner class MovieViewHolder(val binding: ViewDataBinding, private val onMovieItemListener: OnMovieItemListener) :
+            RecyclerView.ViewHolder(binding.root) {
+        init {
+            itemView.setOnClickListener {
+                val pos = adapterPosition
+                if (pos != NO_POSITION) {
+                    onMovieItemListener.onMovieClicked(pos)
+                }
+            }
+        }
+    }
 
 }
 

--- a/app/src/main/java/com/example/moviedb/delegates/MovieDelegateAdapter.kt
+++ b/app/src/main/java/com/example/moviedb/delegates/MovieDelegateAdapter.kt
@@ -16,10 +16,24 @@ import com.squareup.picasso.Picasso
 
 class MovieDelegateAdapter : DelegateAdapter {
 
+    companion object {
+        @BindingAdapter("bind_imageUrl")
+        @JvmStatic
+        fun loadImage(view: ImageView, imageUrl: String?) {
+            if (!imageUrl.isNullOrEmpty()) {
+                Picasso.get()
+                        .load(imageUrl)
+                        .placeholder(R.drawable.ic_movies_24px)
+                        .error(R.drawable.ic_movies_24px)
+                        .into(view)
+            }
+        }
+    }
+
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
-        val viewDataBinding = DataBindingUtil.inflate<ViewDataBinding>(
-                layoutInflater, R.layout.item_movie, parent, false)
+        val viewDataBinding = DataBindingUtil.inflate<ViewDataBinding>(layoutInflater, R.layout.item_movie, parent, false)
         return MovieViewHolder(viewDataBinding)
     }
 
@@ -30,17 +44,6 @@ class MovieDelegateAdapter : DelegateAdapter {
         }
     }
 
-    @BindingAdapter("bind_imageUrl")
-    fun loadImage(view: ImageView, imageUrl: String?) {
-        if (!imageUrl.isNullOrEmpty()) {
-            Picasso.Builder(view.context)
-                    .build()
-                    .load(imageUrl)
-                    .placeholder(R.drawable.ic_movies_24px)
-                    .error(R.drawable.ic_movies_24px)
-                    .into(view)
-        }
-    }
 
     inner class MovieViewHolder(val binding: ViewDataBinding) :
             RecyclerView.ViewHolder(binding.root)

--- a/app/src/main/java/com/example/moviedb/networking/services/MovieService.kt
+++ b/app/src/main/java/com/example/moviedb/networking/services/MovieService.kt
@@ -6,6 +6,6 @@ import io.reactivex.Observable
 import retrofit2.http.GET
 
 interface MovieService {
-    @GET("/movie/popular")
+    @GET("/3/movie/popular")
     fun getPopular(): Observable<Response<Movie>>
 }

--- a/app/src/main/java/com/example/moviedb/viewmodels/MovieViewModel.kt
+++ b/app/src/main/java/com/example/moviedb/viewmodels/MovieViewModel.kt
@@ -1,0 +1,9 @@
+package com.example.moviedb.viewmodels
+
+import com.example.moviedb.models.Movie
+import com.example.moviedb.repositories.MovieRepository
+import io.reactivex.Observable
+
+class MovieViewModel(private val repository: MovieRepository) {
+    fun getPopularMovies(): Observable<Movie> = repository.getPopular()
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/swipe_refresh_layout"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior"
-    tools:context=".activities.MainActivity"
-    tools:showIn="@layout/activity_main">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerview"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipe_refresh_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:context=".activities.MainActivity"
+        tools:showIn="@layout/activity_main">
 
-</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerview"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+</layout>

--- a/app/src/main/res/layout/item_movie.xml
+++ b/app/src/main/res/layout/item_movie.xml
@@ -17,10 +17,10 @@
 
         <ImageView
             android:id="@+id/imageview_poster"
-            android:layout_width="@dimen/ic_dimen_48dp"
-            android:layout_height="@dimen/ic_dimen_48dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_margin="@dimen/normal_margin"
-            android:src="@drawable/ic_movies_24px"
+            tools:src="@drawable/ic_movies_24px"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.0"


### PR DESCRIPTION
## WHAT'S IN

- Added MovieItemDecorator to allow the items in the recyclerview to have margins between them.
- Added the MoviewViewModel class to bridge the activity and the data source.
- Added OkHttp interceptor to facilitate network calls debugging.
- Updated the API and Image URLs on the build.gradle file to match retrofit/android requirements over URL structure and HTTPS connections on Android P.
- Updated the DI Module to fix init issues related to Realm.
- Updated item_movie.xml layout file to wrap the image content and to only have the tools source option instead of the android one.
- Updated activity_main.xml layout file to include the layout main node on the XML to enable databindings on the Activity.
- Updated MovieDelegateAdapter to have the BindingAdapter as static inside the companion object and fixing some indentation issues.
- Added code in the MainActivity to have the databinding, draw the items and have the adapter and observer code.
-  Added click listeners and navigation to the MovieDetailActivity from the MainActivity when clicking an item on the list