### PR TITLE
Fix offline mode and RealmDB threading errors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ android {
             buildConfigField "String", "API_BASE_URL_V3", "\"https://api.themoviedb.org/\""
             buildConfigField "String", "POSTER_BASE_URL", "\"https://image.tmdb.org/t/p/w154//\""
             //TODO replace the API KEY with the one issued from TMDB
-            buildConfigField "String", "API_KEY", "\"f19d91a5929903ec923e8d9f11ae024d\""
+            buildConfigField "String", "API_KEY", "\"API_KEY\""
         }
         release {
             minifyEnabled true
@@ -35,7 +35,7 @@ android {
             buildConfigField "String", "API_BASE_URL_V3", "\"https://api.themoviedb.org/\""
             buildConfigField "String", "POSTER_BASE_URL", "\"https://image.tmdb.org/t/p/w154//\""
             //TODO replace the API KEY with the one issued from TMDB
-            buildConfigField "String", "API_KEY", "\"f19d91a5929903ec923e8d9f11ae024d\""
+            buildConfigField "String", "API_KEY", "\"API_KEY\""
         }
     }
     compileOptions {

--- a/app/src/main/java/com/example/moviedb/MovieDBApplication.kt
+++ b/app/src/main/java/com/example/moviedb/MovieDBApplication.kt
@@ -20,9 +20,7 @@ class MovieDBApplication : Application() {
 
     private val appModule by lazy {
         module {
-            single { Realm.init(this@MovieDBApplication) }
-            single { Realm.getDefaultInstance() }
-            single { LocalMovieSource(get()) }
+            single { LocalMovieSource() }
             single {
                 val httpLoggingInterceptor = HttpLoggingInterceptor()
                 httpLoggingInterceptor.level = HttpLoggingInterceptor.Level.BASIC

--- a/app/src/main/java/com/example/moviedb/sources/LocalMovieSource.kt
+++ b/app/src/main/java/com/example/moviedb/sources/LocalMovieSource.kt
@@ -1,31 +1,41 @@
 package com.example.moviedb.sources
 
 import com.example.moviedb.models.Movie
-import io.reactivex.Completable
-import io.reactivex.CompletableEmitter
 import io.reactivex.Observable
+import io.reactivex.ObservableEmitter
 import io.realm.Realm
 
-class LocalMovieSource(private val realm: Realm) : MovieSource {
+class LocalMovieSource : MovieSource {
+
+
     override fun getPopularMovies(): Observable<Movie> {
-        val result = realm.where(Movie::class.java).findAll()
-        return result.asChangesetObservable()
-                .flatMapIterable { it.collection }
+        return Observable.create<List<Movie>> { emitter: ObservableEmitter<List<Movie>> ->
+            val realm = Realm.getDefaultInstance()
+            try {
+                val result = realm.where(Movie::class.java).findAll()
+                emitter.onNext(realm.copyFromRealm(result.toList()))
+                emitter.onComplete()
+            } catch (e: java.lang.IllegalStateException) {
+                emitter.onError(e)
+            } finally {
+                realm.close()
+            }
+        }.flatMapIterable { it }
     }
 
-    override fun saveMovies(movies: List<Movie>): Completable {
-        return Completable.create { emitter: CompletableEmitter ->
-            realm.executeTransactionAsync({ realm.apply { copyToRealmOrUpdate(movies) } },
-                    { emitter.onComplete() },
-                    { error -> emitter.onError(error) })
-        }
-    }
-
-    override fun saveMovie(movie: Movie): Completable {
-        return Completable.create { emitter: CompletableEmitter ->
-            realm.executeTransactionAsync({ realm.apply { copyToRealmOrUpdate(movie) } },
-                    { emitter.onComplete() },
-                    { error -> emitter.onError(error) })
+    override fun saveMovie(movie: Movie): Observable<Movie> {
+        return Observable.create { emitter: ObservableEmitter<Movie> ->
+            val realm = Realm.getDefaultInstance()
+            try {
+                realm.beginTransaction()
+                emitter.onNext(realm.copyToRealmOrUpdate(movie))
+            } catch (e: java.lang.IllegalStateException) {
+                emitter.onError(e)
+            } finally {
+                realm.commitTransaction()
+                realm.close()
+                emitter.onComplete()
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/moviedb/sources/MovieSource.kt
+++ b/app/src/main/java/com/example/moviedb/sources/MovieSource.kt
@@ -1,11 +1,9 @@
 package com.example.moviedb.sources
 
 import com.example.moviedb.models.Movie
-import io.reactivex.Completable
 import io.reactivex.Observable
 
 interface MovieSource {
     fun getPopularMovies(): Observable<Movie>
-    fun saveMovies(movies: List<Movie>): Completable
-    fun saveMovie(movie: Movie): Completable
+    fun saveMovie(movie: Movie): Observable<Movie>
 }

--- a/app/src/main/java/com/example/moviedb/sources/RemoteMovieSource.kt
+++ b/app/src/main/java/com/example/moviedb/sources/RemoteMovieSource.kt
@@ -4,7 +4,6 @@ import com.example.moviedb.BuildConfig
 import com.example.moviedb.models.Movie
 import com.example.moviedb.networking.models.Response
 import com.example.moviedb.networking.services.MovieService
-import io.reactivex.Completable
 import io.reactivex.Observable
 
 class RemoteMovieSource(private val movieService: MovieService) : MovieSource {
@@ -20,11 +19,7 @@ class RemoteMovieSource(private val movieService: MovieService) : MovieSource {
                 }
     }
 
-    override fun saveMovies(movies: List<Movie>): Completable {
-        throw UnsupportedOperationException("TMDB API does not support this operation")
-    }
-
-    override fun saveMovie(movie: Movie): Completable {
+    override fun saveMovie(movie: Movie): Observable<Movie> {
         throw UnsupportedOperationException("TMDB API does not support this operation")
     }
 }


### PR DESCRIPTION
## WHAT'S IN

- Updated DI to allow Realm sessions to be closed on demand.
- Fixed offline mode to allow the user to see the movies when there is no internet connection
- Removed unnecessary methods and imports from the Movie sources.
- *Removed old API key that is now UNUSABLE to avoid security issues.*